### PR TITLE
Add progress listener when starting upload to s3

### DIFF
--- a/src/onyx/plugin/s3_output.clj
+++ b/src/onyx/plugin/s3_output.clj
@@ -13,8 +13,7 @@
             [schema.core :as s]
             [taoensso.timbre :as timbre :refer [error warn info trace]])
   (:import [com.amazonaws.event ProgressEventType]
-           [com.amazonaws.event ProgressListener]
-           ;[com.amazonaws.services.s3.transfer.internal S3ProgressListener]
+           [com.amazonaws.services.s3.transfer.internal S3ProgressListener]
            [com.amazonaws.services.s3.transfer TransferManager Upload Transfer$TransferState]
            [java.util TimeZone]
            [java.text SimpleDateFormat]))
@@ -37,8 +36,8 @@
 
 
 (defn build-ack-listener [fail-fn complete-fn peer-replica-view messenger acks]
-  (let [start-time (System/currentTimeMillis)] 
-    (reify ProgressListener
+  (let [start-time (System/currentTimeMillis)]
+    (reify S3ProgressListener
       (progressChanged [this progressEvent]
         (let [event-type (.getEventType progressEvent)] 
           ;; TODO:

--- a/src/onyx/plugin/s3_utils.clj
+++ b/src/onyx/plugin/s3_utils.clj
@@ -6,9 +6,8 @@
            [com.amazonaws.services.s3.model ObjectMetadata]
            [java.io ByteArrayInputStream]
            [com.amazonaws.services.s3.transfer TransferManager Upload]
-           [com.amazonaws.event ProgressListener]
            [com.amazonaws.event ProgressListener$ExceptionReporter]
-           ;[com.amazonaws.services.s3.transfer.internal S3ProgressListener]
+           [com.amazonaws.services.s3.transfer.internal S3ProgressListener]
            [com.amazonaws.event ProgressEventType]
            [org.apache.commons.codec.digest DigestUtils]
            [com.amazonaws.services.s3.model PutObjectRequest]
@@ -27,7 +26,7 @@
   (let [credentials (DefaultAWSCredentialsProviderChain.)] 
     (TransferManager. (AmazonS3Client. credentials))))
 
-(defn upload [^TransferManager transfer-manager ^String bucket ^String key ^bytes serialized ^String content-type ^ProgressListener progress-listener]
+(defn upload [^TransferManager transfer-manager ^String bucket ^String key ^bytes serialized ^String content-type ^S3ProgressListener progress-listener]
   (let [size (alength serialized)
         md5 (String. (Base64/encodeBase64 (DigestUtils/md5 serialized)))
         metadata (doto (ObjectMetadata.)
@@ -41,10 +40,5 @@
                                        key
                                        (ByteArrayInputStream. serialized)
                                        metadata)
-        upload ^Upload (.upload transfer-manager 
-                                bucket
-                                key
-                                (ByteArrayInputStream. serialized)
-                                metadata)]
-    (doto upload
-      (.addProgressListener progress-listener))))
+        upload ^Upload (.upload transfer-manager put-request progress-listener)]
+    upload))


### PR DESCRIPTION
instead of attaching it to the upload after it has started
which may cause the listener to miss events, especially
for small uploads