### PR TITLE
Allow specifying `:s3/transfer-manager-threadpool-size` on the S3 output plugin

### DIFF
--- a/src/onyx/plugin/s3_output.clj
+++ b/src/onyx/plugin/s3_output.clj
@@ -120,16 +120,17 @@
   (let [_ (s/validate (os/UniqueTaskMap S3OutputTaskMap) task-map)
         {:keys [s3/bucket s3/serializer-fn s3/key-naming-fn s3/access-key s3/secret-key
                 s3/content-type s3/region s3/endpoint-url s3/prefix s3/serialize-per-element? s3/prefix-separator
+                s3/transfer-manager-threadpool-size
                 s3/multi-upload s3/prefix-key]} task-map
         encryption (or (:s3/encryption task-map) :none)
         max-concurrent-uploads (or (:s3/max-concurrent-uploads task-map) Long/MAX_VALUE)
         prefix-separator (or prefix-separator "/")
         client (s3/new-client :access-key access-key :secret-key secret-key
                               :region region :endpoint-url endpoint-url)
-        transfer-manager (s3/transfer-manager client)
+        transfer-manager (s3/transfer-manager client transfer-manager-threadpool-size)
         serializer-fn (kw->fn serializer-fn)
         separator (or (:s3/serialize-per-element-separator task-map) "\n")
-        serializer-fn (if serialize-per-element? 
+        serializer-fn (if serialize-per-element?
                         (fn [segments] (serialize-per-element serializer-fn separator segments))
                         serializer-fn)
         key-naming-fn (kw->fn key-naming-fn)

--- a/src/onyx/plugin/s3_utils.clj
+++ b/src/onyx/plugin/s3_utils.clj
@@ -11,6 +11,7 @@
            [com.amazonaws.event ProgressEventType]
            [java.io ByteArrayInputStream InputStreamReader BufferedReader]
            [org.apache.commons.codec.digest DigestUtils]
+           [java.util.concurrent ExecutorService Executors]
            [org.apache.commons.codec.binary Base64]))
 
 (defn new-client ^AmazonS3Client
@@ -21,8 +22,14 @@
                            endpoint-url ^AmazonS3ClientBuilder (.withEndpointConfiguration (AwsClientBuilder$EndpointConfiguration. endpoint-url region)))]
     (.build builder)))
 
-(defn transfer-manager ^TransferManager [^AmazonS3Client client]
-  (TransferManager. client))
+(defn transfer-manager ^TransferManager
+  ([^AmazonS3Client client]
+   (TransferManager. client))
+  ([^AmazonS3Client client n-threads]
+   (if n-threads
+     (let [executor-service ^ExecutorService (Executors/newFixedThreadPool n-threads)]
+       (TransferManager. client executor-service))
+     (transfer-manager client))))
 
 (defn upload [^TransferManager transfer-manager ^String bucket ^String key
               ^bytes serialized ^String content-type encryption]

--- a/src/onyx/s3/information_model.cljc
+++ b/src/onyx/s3/information_model.cljc
@@ -101,16 +101,21 @@
               :optional? true
               :type :string}
 
-             :s3/content-type 
+             :s3/content-type
              {:doc "Optional content type for S3 object."
               :optional? true
               :type :string}
 
-             :s3/encryption 
+             :s3/encryption
              {:doc "Optional server side encryption setting."
               :choices [:none :aes256]
               :optional? true
-              :type :keyword}}}}
+              :type :keyword}
+             :s3/transfer-manager-threadpool-size
+             {:doc "Optional transfer manager thread pool size."
+              :optional? true
+              :type :int}
+             }}}
 
    :lifecycle-entry
    {:onyx.plugin.s3-input/input

--- a/src/onyx/tasks/s3.clj
+++ b/src/onyx/tasks/s3.clj
@@ -25,6 +25,7 @@
    (s/optional-key :s3/prefix-key) s/Keyword
    (s/optional-key :s3/prefix-separator) s/Str
    (s/optional-key :s3/max-concurrent-uploads) s/Int
+   (s/optional-key :s3/transfer-manager-threadpool-size) s/Int
    (os/restricted-ns :s3) s/Any})
 
 (s/defn ^:always-validate s3-output
@@ -51,7 +52,7 @@
                                 :s3/serializer-fn serializer-fn}
                                task-opts))))
 
-(def S3InputTaskMap 
+(def S3InputTaskMap
   {:s3/deserializer-fn os/NamespacedKeyword
    :s3/bucket s/Str
    :s3/prefix s/Str

--- a/test/onyx/plugin/s3_output_test.clj
+++ b/test/onyx/plugin/s3_output_test.clj
@@ -81,13 +81,14 @@
                                                 ::serializer-fn
                                                 {:onyx/max-peers 1
                                                  :s3/encryption :aes256
+                                                 :s3/transfer-manager-threadpool-size 4
                                                  :onyx/batch-timeout 2000
                                                  :onyx/batch-size 2000})))
               _ (reset! in-chan (chan (inc n-messages)))
               _ (reset! in-buffer {})
               input-messages (map (fn [v] {:n v
                                            :some-string1 "This is a string that I will increase the length of to test throughput"
-                                           :some-string2 "This is a string that I will increase the length of to test throughput"}) 
+                                           :some-string2 "This is a string that I will increase the length of to test throughput"})
                                   (range n-messages))]
           (run! #(>!! @in-chan %) input-messages)
           (close! @in-chan)


### PR DESCRIPTION
The ExecutorService that gets created is GC'd when the TransferManager is GC'd. 